### PR TITLE
Removed unused dateutil import

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -4,7 +4,7 @@ import os,shutil
 import re
 import sys
 import time
-import datetime, dateutil
+import datetime
 
 
 sys.path.append("build")


### PR DESCRIPTION
Caused fab to fail with this error :

```
ImportError: No module named dateutil
```

While the module is not used anywhere
