### PR TITLE
Fix panel's itemTemplate, adding missing 'underscore' require.

### DIFF
--- a/lib/uielements/panel.js
+++ b/lib/uielements/panel.js
@@ -9,7 +9,7 @@
  * Date: Wed Jul 20 20:23:43 2011
  */
 
-Joshfire.define(['joshfire/uielement', 'joshfire/class'], function(UIElement, Class) {
+Joshfire.define(['joshfire/uielement', 'joshfire/class', 'joshfire/vendor/underscore'], function(UIElement, Class, _) {
   /**
   * @class Panel base class
   * @name uielements_panel
@@ -32,7 +32,7 @@ Joshfire.define(['joshfire/uielement', 'joshfire/class'], function(UIElement, Cl
               var tplFunc = (_.isFunction(this.options.itemTemplate)) ?  this.options.itemTemplate : _.template(this.options.itemTemplate);
               this.item = this.data || {};
               return content =tplFunc(this);
-            } 
+            }
             if (this.options.content) {
               return this.options.content;
             } else {


### PR DESCRIPTION
Using itemTemplate in a Panel does not work right now, due to a missing require for the underscore library.
